### PR TITLE
Aarch64

### DIFF
--- a/org.freedesktop.Sdk.Extension.texlive.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.texlive.appdata.xml
@@ -4,4 +4,8 @@
   <metadata_license>CC0-1.0</metadata_license>
   <name>TeX Live Sdk extension</name>
   <summary>LaTeX packages and tools</summary>
+  <url type="homepage">https://tug.org/texlive/</url>
+  <releases>
+    <release date="2020-04-06" version="2020.04.06" />
+  </releases>
 </component>

--- a/org.freedesktop.Sdk.Extension.texlive.yml
+++ b/org.freedesktop.Sdk.Extension.texlive.yml
@@ -21,11 +21,17 @@ modules:
       - --without-x # needs additonal dependencies
       - --disable-native-texlive-build
       - --with-system-cairo
+      - --with-system-fontconfig
       - --with-system-freetype2
+      - --with-system-gmp
+      - --with-system-graphite2
       - --with-system-harfbuzz
       - --with-system-icu
       - --with-system-libpng
+      - --with-system-pixman
       - --with-system-zlib
+    post-install:
+      - make texlinks
     # Hints for a proper installation can be found in http://www.linuxfromscratch.org/blfs/view/svn/pst/texlive.html or http://ftp.math.utah.edu/pub/texlive-utah/ .
     sources:
       - type: archive

--- a/org.freedesktop.Sdk.Extension.texlive.yml
+++ b/org.freedesktop.Sdk.Extension.texlive.yml
@@ -15,23 +15,17 @@ modules:
     buildsystem: autotools
     builddir: true
     build-options:
-      arch:
-        aarch64:
-          ldflags: -ldl
+      ldflags: -ldl
     config-opts:
-      - --bindir=${FLATPAK_DEST}/bin/${FLATPAK_ARCH}
-      - --datarootdir=${FLATPAK_DEST}/share
-      - --disable-xetex # needs additonal dependencies
-      - --disable-xindy # needs additonal dependencies
-      - --exec_prefix=${FLATPAK_DEST}
-      - --includedir=${FLATPAK_DEST}/include
-      - --infodir=${FLATPAK_DEST}/share/info
-      - --libdir=${FLATPAK_DEST}/lib
-      - --mandir=${FLATPAK_DEST}/share/man
-      - --prefix=${FLATPAK_DEST}
+      - --bindir=${FLATPAK_DEST}/bin/${FLATPAK_ARCH}-linux
       - --without-x # needs additonal dependencies
       - --disable-native-texlive-build
+      - --with-system-cairo
+      - --with-system-freetype2
+      - --with-system-harfbuzz
+      - --with-system-icu
       - --with-system-libpng
+      - --with-system-zlib
     # Hints for a proper installation can be found in http://www.linuxfromscratch.org/blfs/view/svn/pst/texlive.html or http://ftp.math.utah.edu/pub/texlive-utah/ .
     sources:
       - type: archive

--- a/org.freedesktop.Sdk.Extension.texlive.yml
+++ b/org.freedesktop.Sdk.Extension.texlive.yml
@@ -51,8 +51,8 @@ modules:
     sources:
       - type: script
         commands:
-          - install -d ${FLATPAK_DEST}/texlive
-          - cp -ra /usr/lib/sdk/texlive/* ${FLATPAK_DEST}/texlive
+          - install -d ${FLATPAK_DEST}
+          - cp -ra /usr/lib/sdk/texlive/* ${FLATPAK_DEST}
         dest-filename: install.sh
       - type: script
         commands:

--- a/org.freedesktop.Sdk.Extension.texlive.yml
+++ b/org.freedesktop.Sdk.Extension.texlive.yml
@@ -62,5 +62,5 @@ modules:
         dest-filename: install.sh
       - type: script
         commands:
-          - export PATH=/usr/lib/sdk/texlive/bin/${FLATPAK_ARCH}:/usr/lib/sdk/texlive/bin:$PATH
+          - export PATH=/usr/lib/sdk/texlive/bin/${FLATPAK_ARCH}-linux:/usr/lib/sdk/texlive/bin:$PATH
         dest-filename: enable.sh


### PR DESCRIPTION
This one should build better.

But the build process doesn't create the symlinks for, eg. `xelatex` (amongst others)