### PR TITLE
Fix clisp build

### DIFF
--- a/org.freedesktop.Sdk.Extension.texlive.yml
+++ b/org.freedesktop.Sdk.Extension.texlive.yml
@@ -110,10 +110,19 @@ modules:
         url: https://github.com/mgieseki/dvisvgm/releases/download/2.10.1/dvisvgm-2.10.1.tar.gz
         md5: e1fa5d5ce656fedcdb7cd4146220e181
   - name: clisp
+    modules:
+      - name: libsigsegv
+        sources:
+          - type: archive
+            url: https://ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.12.tar.gz
+            sha256: 3ae1af359eebaa4ffc5896a1aee3568c052c99879316a1ab57f8fe1789c390b6
     sources:
     - type: archive
-      url: https://ftp.gnu.org/gnu/clisp/latest/clisp-2.49.tar.bz2
-      sha256: 8132ff353afaa70e6b19367a25ae3d5a43627279c25647c220641fed00f8e890
+      url: https://deb.debian.org/debian/pool/main/c/clisp/clisp_2.49.20180218+really2.49.92.orig.tar.bz2
+      sha256: bd443a94aa9b02da4c4abbcecfc04ffff1919c0a8b0e7e35649b86198cd6bb89
+    - type: shell
+      commands:
+        - cp -p /usr/share/automake-*/config.{sub,guess} src/build-aux
   - name: xindy
     config-opts:
     - --bindir=${FLATPAK_DEST}/bin/${FLATPAK_ARCH}-linux


### PR DESCRIPTION
This is needed for aarch64. After that it stops at the same place as x86_64.